### PR TITLE
Fix __all__ to export that class that is defined

### DIFF
--- a/sync_batchnorm/batchnorm_reimpl.py
+++ b/sync_batchnorm/batchnorm_reimpl.py
@@ -12,7 +12,7 @@ import torch
 import torch.nn as nn
 import torch.nn.init as init
 
-__all__ = ['BatchNormReimpl']
+__all__ = ['BatchNorm2dReimpl']
 
 
 class BatchNorm2dReimpl(nn.Module):


### PR DESCRIPTION
__BatchNormReimpl__ is an _undefined name_ while __BatchNorm2dReimpl__ is defined 3 lines below.

[flake8](http://flake8.pycqa.org) testing of https://github.com/ajbrock/BigGAN-PyTorch on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./sync_batchnorm/batchnorm_reimpl.py:15:1: F822 undefined name 'BatchNormReimpl' in __all__
__all__ = ['BatchNormReimpl']
^
1     F822 undefined name 'BatchNormReimpl' in __all__
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree