### PR TITLE
Add arch[512] in discriminator and fix arch[256]

### DIFF
--- a/BigGAN.py
+++ b/BigGAN.py
@@ -254,12 +254,18 @@ class Generator(nn.Module):
 # Discriminator architecture, same paradigm as G's above
 def D_arch(ch=64, attention='64',ksize='333333', dilation='111111'):
   arch = {}
+   arch[512] = {'in_channels' :  [3] + [ch*item for item in [1, 1, 2, 4, 8, 8, 16]],
+               'out_channels' : [item * ch for item in [1, 1, 2, 4, 8, 8, 16, 16]],
+               'downsample' : [True] * 7 + [False],
+               'resolution' : [256, 128, 64, 32, 16, 8, 4, 4 ],
+               'attention' : {2**i: 2**i in [int(item) for item in attention.split('_')]
+                              for i in range(2,10)}}
   arch[256] = {'in_channels' :  [3] + [ch*item for item in [1, 2, 4, 8, 8, 16]],
                'out_channels' : [item * ch for item in [1, 2, 4, 8, 8, 16, 16]],
                'downsample' : [True] * 6 + [False],
                'resolution' : [128, 64, 32, 16, 8, 4, 4 ],
                'attention' : {2**i: 2**i in [int(item) for item in attention.split('_')]
-                              for i in range(2,8)}}
+                              for i in range(2,9)}}
   arch[128] = {'in_channels' :  [3] + [ch*item for item in [1, 2, 4, 8, 16]],
                'out_channels' : [item * ch for item in [1, 2, 4, 8, 16, 16]],
                'downsample' : [True] * 5 + [False],


### PR DESCRIPTION
Add arch for 256x256 images in discriminator and fix off-by one in arch[256] attention parameter.
Taken from https://github.com/ajbrock/BigGAN-PyTorch/issues/40